### PR TITLE
[perf] Replace hardcoded padding-top and eliminate double getCollection (NEU-112)

### DIFF
--- a/src/pages/insights/[slug].astro
+++ b/src/pages/insights/[slug].astro
@@ -13,7 +13,7 @@ export async function getStaticPaths() {
   return [
     ...articles.map((entry) => ({
       params: { slug: entry.id },
-      props: { entry, contentType: 'article' as const },
+      props: { entry, contentType: 'article' as const, allArticles: articles },
     })),
     ...pages.map((entry) => ({
       params: { slug: entry.id },
@@ -26,7 +26,7 @@ export async function getStaticPaths() {
   ];
 }
 
-const { entry, contentType } = Astro.props;
+const { entry, contentType, allArticles = [] } = Astro.props;
 const { Content } = await render(entry);
 
 // --- SEO fields (unified across content types) ---
@@ -158,8 +158,7 @@ if (faqItems.length > 0) {
   jsonLdSchemas.push(faqSchema);
 }
 
-// Related articles (for article content type)
-const allArticles = contentType === 'article' ? await getCollection('articles') : [];
+// Related articles (for article content type) — allArticles passed via props from getStaticPaths()
 const manualRelatedSlugs: string[] = (entry.data as any).relatedArticles || [];
 const relatedArticles = allArticles.filter((a) => a.id !== entry.id && (
   manualRelatedSlugs.length > 0

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -205,7 +205,7 @@ h1, h2, h3, h4, h5, h6 {
 
 /* Position main content to account for the fixed header */
 main {
-  padding-top: 88px;
+  padding-top: var(--header-height);
 }
 
 /* ----- Logo ----- */


### PR DESCRIPTION
## Summary
- `global.css`: replace `padding-top: 88px` with `padding-top: var(--header-height)` — eliminates maintenance risk if header height changes
- `insights/[slug].astro`: pass `allArticles` through `getStaticPaths()` props; remove redundant `await getCollection('articles')` call at render time

## Pattern applied
Both fixes generalize patterns already merged in PR #23 and PR #24. The CSS variable was introduced in BaseLayout.astro (PR #23) but never applied in global.css. The prop-passing pattern was used in `articles/[slug].astro` (PR #24) but not in `insights/[slug].astro`.

## Test plan
- [x] `npm run build` — passes, all 29 pages rendered
- [ ] Visual check on an insights article page (no layout shift, header clearance unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)