### PR TITLE
[perf] Add missing image performance attributes across pages (NEU-113)

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -98,7 +98,7 @@ const aboutPageSchema = {
           <div class="about-story__image-wrap" data-reveal="up" style="--delay:0.2s">
             <picture>
               <source srcset="/images/how-it-works.webp" type="image/webp">
-              <img src="/images/how-it-works.jpg" alt="Orderflow dashboard showing order processing pipeline" class="about-story__image" width="1066" height="1280" fetchpriority="high" loading="eager">
+              <img src="/images/how-it-works.jpg" alt="Orderflow dashboard showing order processing pipeline" class="about-story__image" width="1066" height="1280" fetchpriority="high" loading="eager" decoding="sync">
             </picture>
           </div>
         </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -476,7 +476,7 @@ const faqSchema = {
               <a href={`/insights/${item.id}`} class="insight-card">
                 <div class="insight-card__image-wrap">
                   <span class="insight-card__category">{item.category}</span>
-                  {item.image && <img src={item.image} alt={item.title} class="insight-card__image" loading="lazy">}
+                  {item.image && <img src={item.image} alt={item.title} class="insight-card__image" width="816" height="640" loading="lazy">}
                 </div>
                 <div class="insight-card__body">
                   <p class="insight-card__date">{item.dateFormatted}</p>

--- a/src/pages/insights.astro
+++ b/src/pages/insights.astro
@@ -116,7 +116,7 @@ const allTags = [...new Set(allItems.map((item) => item.filterTag))];
           {sortedItems.map((item, index) => (
             <a href={`/insights/${item.id}`} class="article-card" data-reveal="up" data-tag={item.filterTag}>
               <div class="article-card__image-wrap">
-                {item.image && <img src={item.image} alt={item.title} class="article-card__image" loading={index === 0 ? 'eager' : 'lazy'} fetchpriority={index === 0 ? 'high' : undefined}>}
+                {item.image && <img src={item.image} alt={item.title} class="article-card__image" width="816" height="640" loading={index === 0 ? 'eager' : 'lazy'} fetchpriority={index === 0 ? 'high' : undefined}>}
                 {(item.category || item.contentTypeLabel) && (
                   <span class="article-card__tag">{item.category || item.contentTypeLabel}</span>
                 )}


### PR DESCRIPTION
## Summary

- `about.astro`: Add `decoding="sync"` to hero image (matches pattern from articles/insights slug pages)
- `insights.astro`: Add `width="816" height="640"` to article listing card images (prevents CLS)
- `index.astro`: Add `width="816" height="640"` to homepage insight-card images (prevents CLS)

## Changes

All three are mechanical pattern-matches from fixes already applied in PRs #24 and #25.

## Test plan
- [ ] Build passes (`npm run build`) ✅
- [ ] No visual regression on `/about`, `/insights`, `/` (homepage insight section)
- [ ] Lighthouse: no CLS introduced by missing dimensions

Fixes NEU-113