### PR TITLE
Fix oversized related article images on article pages (NEU-114)

### DIFF
--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -76,7 +76,15 @@
 
 @media (max-width: 640px) {
   .section--related-articles .insight-cards {
+    display: grid;
     grid-template-columns: 1fr;
+    overflow-x: visible;
+    scroll-snap-type: none;
+    padding-bottom: 0;
+  }
+
+  .section--related-articles .insight-cards > li {
+    flex: initial;
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds scoped CSS overrides for `.section--related-articles` in `content.css`
- Constrains the related articles grid to `max-width: 960px` (was full-width)
- Replaces fixed `height: 240px` image wrap with `aspect-ratio: 408/320` matching the insights listing page
- Adds responsive breakpoints (2-col tablet, 1-col mobile) and hover transitions

## Test plan
- [ ] Visit https://orderflow.biz/insights/order-processing-software-distributors and scroll to "Continue reading"
- [ ] Verify images are proportionally sized and not oversized
- [ ] Check the section is centered with reasonable max-width
- [ ] Verify homepage insight cards are unaffected
- [ ] Test at mobile/tablet breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)