### PR TITLE
Fix /demo 404 — redirect to /contact and update article CTAs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,6 +16,9 @@ export default defineConfig({
   output: 'static',
   adapter,
   site: 'https://orderflow.biz',
+  redirects: {
+    '/demo': '/contact',
+  },
   integrations: [
     react(),
     markdoc(),

--- a/src/content/articles/order-processing-software-distributors.mdoc
+++ b/src/content/articles/order-processing-software-distributors.mdoc
@@ -224,7 +224,7 @@ These numbers come from live production, not a controlled test. The 98% figure i
 
 The business impact maps directly to the industry benchmarks: at a 3% manual error rate across 300+ daily orders, Meesenburg was generating thousands of errors per year before automation. Industry data puts the fully loaded cost of a single order error at $18,000 when you account for returns, re-shipments, credit notes, and the downstream customer churn risk. The same research shows that 85% of B2B customers are likely to reduce spending or leave after experiencing just three errors with a supplier. At that scale, the ROI calculation doesn't require sophisticated modeling.
 
-[See how OrderFlow works](/demo)
+[See how OrderFlow works](/contact)
 
 ## How to Choose the Right Tool for Your Business
 
@@ -270,4 +270,4 @@ A distributor processing 300 orders per day at a 3% manual error rate generates 
 
 ---
 
-[Book a Free Demo](/demo)
+[Book a Free Demo](/contact)


### PR DESCRIPTION
## Summary

- Added `/demo` → `/contact` redirect in `astro.config.mjs` as a catch-all for any `/demo` links
- Updated two CTA links in `order-processing-software-distributors.mdoc` to point to `/contact` directly

Fixes NEU-135

## Test plan

- [ ] Navigate to `/insights/order-processing-software-distributors` — verify "See how OrderFlow works" links to `/contact`
- [ ] Verify "Book a Free Demo" at article bottom links to `/contact`
- [ ] Navigate to `/demo` directly — verify redirect to `/contact`
- [ ] Verify `/contact` page renders correctly with demo booking form

## Verification

Tested locally with `astro dev`:
- Both CTAs confirmed pointing to `/contact`
- `/demo` redirect confirmed — navigates to `/contact` page