### PR TITLE
Fix related insights date format to match homepage

### DIFF
--- a/src/pages/insights/[slug].astro
+++ b/src/pages/insights/[slug].astro
@@ -169,6 +169,14 @@ const relatedArticles = allArticles.filter((a) => a.id !== entry.id && (
 // Case study specific data
 const stats = contentType === 'caseStudy' ? ((entry.data as any).stats || []) : [];
 
+function formatDate(dateStr: string): string {
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  const day = String(d.getDate()).padStart(2, '0');
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  return `${day} ${months[d.getMonth()]} ${d.getFullYear()}`;
+}
+
 ---
 
 <BaseLayout
@@ -267,7 +275,7 @@ const stats = contentType === 'caseStudy' ? ((entry.data as any).stats || []) : 
                     {related.data.image && <img src={related.data.image} alt={related.data.title} class="insight-card__image" width="816" height="640" loading="lazy">}
                   </div>
                   <div class="insight-card__body">
-                    <p class="insight-card__date">{related.data.date}</p>
+                    <p class="insight-card__date">{formatDate(related.data.date)}</p>
                     <h3 class="insight-card__title">{related.data.title}</h3>
                   </div>
                 </a>


### PR DESCRIPTION
## Summary
- Related insights on detail pages showed dates in ISO format (2026-03-15) while homepage showed "15 Mar 2026"
- Added `formatDate()` function to `[slug].astro` (same function used in `index.astro`)
- Now both pages render dates identically

## Test plan
- [x] Build passes (`npx astro build`)
- [x] Preview verified: detail page dates show "DD Mon YYYY" format
- [x] Homepage dates unchanged and match detail page format

Fixes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)