### PR TITLE
Add Google Ads conversion tracking for Calendly bookings

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -107,6 +107,7 @@ const allJsonLd = [
         s.onload = function() {
           gtag('js', new Date());
           gtag('config', GA_ID);
+          gtag('config', 'AW-16637671261');
         };
         document.head.appendChild(s);
       }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -337,6 +337,9 @@ const aboutPageSchema = {
               event_category: 'conversion',
               event_label: 'meeting_booked'
             });
+            gtag('event', 'conversion', {
+              'send_to': 'AW-16637671261/_ErjCJLIzo0cEN3uuv09'
+            });
           }
         }
       });

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -177,6 +177,9 @@ const contactSchema = {
               event_category: 'conversion',
               event_label: 'meeting_booked'
             });
+            gtag('event', 'conversion', {
+              'send_to': 'AW-16637671261/_ErjCJLIzo0cEN3uuv09'
+            });
           }
         }
       });

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -606,6 +606,9 @@ const faqSchema = {
               event_category: 'conversion',
               event_label: 'meeting_booked'
             });
+            gtag('event', 'conversion', {
+              'send_to': 'AW-16637671261/_ErjCJLIzo0cEN3uuv09'
+            });
           }
         }
       });


### PR DESCRIPTION
## Summary
- Adds Google Ads tag `AW-16637671261` config to `BaseLayout.astro` so it loads on every page
- Fires `gtag('event', 'conversion', { send_to: 'AW-16637671261/_ErjCJLIzo0cEN3uuv09' })` when a Calendly meeting is scheduled on index, about, and contact pages
- Existing GA4 tracking (`G-Q9RW388339`) remains untouched
- Consent mode defaults unchanged — Google Ads works in cookieless mode with modeled conversions

## Test plan
- [x] `npm run build` passes (25 pages, 0 errors)
- [x] Built HTML contains `AW-16637671261` config in all pages (via BaseLayout)
- [x] Built HTML contains conversion event in all 3 Calendly pages
- [x] GA4 `calendly_meeting_scheduled` event still fires before conversion event
- [x] QA PASS verdict (NEU-179)

Fixes NEU-178.