### PR TITLE
[large-screen] Fix article hero image pixelation at 2550×1440 (NEU-441)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -791,9 +791,10 @@ main {
   background-size: cover;
   background-position: center;
   background-color: var(--color-neutral-900);
-  margin: var(--space-16);
+  margin: var(--space-16) auto;
   border-radius: var(--radius-2xl);
   overflow: hidden;
+  max-width: calc(var(--max-width) - 2 * var(--space-16));
 }
 
 .insight-hero__overlay {


### PR DESCRIPTION
Caps article hero width to prevent 1200px image upscaling 2.1× to 2518px at large screens.\n\nFixes: NEU-441\nPriority: HIGH