### PR TITLE
[large-screen] Add max-width to .section__card backgrounds (NEU-442)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -167,6 +167,8 @@ h1, h2, h3, h4, h5, h6 {
   border-radius: var(--radius-xl);
   overflow: hidden;
   width: 100%;
+  max-width: var(--max-width);
+  margin: 0 auto;
   padding: var(--space-64) var(--space-72) var(--space-96);
 }
 


### PR DESCRIPTION
Adds max-width to .section__card so colored section backgrounds don't span full 2550px width.\n\nFixes: NEU-442\nPriority: HIGH