### PR TITLE
[large-screen] Move insights grid to 4 columns at 2550×1440 (NEU-444)

### DIFF
--- a/src/pages/insights.astro
+++ b/src/pages/insights.astro
@@ -329,8 +329,8 @@ const allTags = [...new Set(allItems.map((item) => item.filterTag))];
   text-overflow: ellipsis;
 }
 
-/* ----- Large-screen breakpoint ----- */
-@media (min-width: 1400px) {
+/* ----- Large-screen breakpoint (2K+) ----- */
+@media (min-width: 2550px) {
   .article-grid {
     grid-template-columns: repeat(4, 1fr);
   }

--- a/src/pages/insights.astro
+++ b/src/pages/insights.astro
@@ -329,6 +329,13 @@ const allTags = [...new Set(allItems.map((item) => item.filterTag))];
   text-overflow: ellipsis;
 }
 
+/* ----- Large-screen breakpoint ----- */
+@media (min-width: 1400px) {
+  .article-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
 /* ----- Responsive ----- */
 @media (max-width: 1024px) {
   .article-grid {


### PR DESCRIPTION
Adds @media (min-width: 2550px) rule to show 4 columns in the insights article grid at QHD screens.\n\nFixes: NEU-444\nPriority: MEDIUM