### PR TITLE
[large-screen] Fix broken/unloaded article thumbnails (NEU-445)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -560,7 +560,8 @@ main {
 
 .section--related-articles .insight-card__image-wrap {
   position: relative;
-  height: 240px;
+  aspect-ratio: 408 / 320;
+  height: auto;
   overflow: hidden;
   border-radius: var(--radius-xl);
 }

--- a/src/styles/homepage.css
+++ b/src/styles/homepage.css
@@ -925,7 +925,8 @@
 
 .insight-card__image-wrap {
   position: relative;
-  height: 240px;
+  aspect-ratio: 408 / 320;
+  height: auto;
   overflow: hidden;
   border-radius: var(--radius-xl);
 }


### PR DESCRIPTION
Replaces fixed height: 240px on .insight-card__image-wrap with aspect-ratio: 408/320 — fixes distorted image strips at 2550px and ensures proper lazy-loading.\n\nFixes: NEU-445\nPriority: MEDIUM