### PR TITLE
[NEU-481] Add form_submit GA4 event to /contact page

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -166,6 +166,10 @@ const contactSchema = {
           });
 
           if (typeof gtag === 'function') {
+            gtag('event', 'form_submit', {
+              form_id: 'contact',
+              page_path: '/contact'
+            });
             gtag('event', 'calendly_opened', {
               event_category: 'conversion',
               event_label: prefix,


### PR DESCRIPTION
## Summary

- Adds `form_submit` GA4 event to the contact form on `/contact`
- Fires on form validation success (terms checked, email + company filled), before Calendly widget loads
- Parameters: `form_id: 'contact'`, `page_path: '/contact'`
- Follows the existing `gtag` pattern used for `calendly_opened` on the same success path

## Why

GA4 records 44 `form_start` events on `/contact` (Apr 1–13) but zero `form_submit` events. Without this event we cannot measure contact form conversion rate or distinguish UX abandonment from a tracking failure.

## Change

4-line addition inside the existing `if (typeof gtag === 'function')` block at `contact.astro:168`.

## Verification

Event fires at form submission success state — after validation passes and before Calendly loads. No UI changes. No other files modified.