### PR TITLE
[seo] Remove duplicate H1 headings from 4 article/case-study bodies (NEU-585)

### DIFF
--- a/src/content/articles/complete-guide-order-processing-automation.mdoc
+++ b/src/content/articles/complete-guide-order-processing-automation.mdoc
@@ -93,8 +93,6 @@ faq:
       alone.
 ---
 
-# The Complete Guide to Order Processing Automation for Distribution
-
 You have decided to automate order processing. The daily reality of 200 emails, three format types, two languages, and a growing error rate has made the status quo untenable. Your team agrees. Your leadership is open to it. Budget discussions have started.
 
 Now you face the harder question: which approach?

--- a/src/content/articles/from-scanned-pdfs-to-erp-ready-data.mdoc
+++ b/src/content/articles/from-scanned-pdfs-to-erp-ready-data.mdoc
@@ -72,8 +72,6 @@ faq:
       is not required to start.
 ---
 
-# From Scanned PDFs to ERP-Ready Data
-
 Monday morning. Your inbox shows 34 new orders. Twelve are scanned PDFs. Three are blurry phone photos of handwritten lists. One is a fax-to-email scan so dark half the text needs guessing.
 
 Your team gets to work. They open each file, squint at the content, cross-reference product names against a catalog with 8,000 entries, and key the line items into the ERP one by one. By noon, half the orders are entered. By 3 PM, someone has transposed a quantity that won't surface until a warehouse picker flags the discrepancy next week.

--- a/src/content/articles/how-ai-processes-email-orders.mdoc
+++ b/src/content/articles/how-ai-processes-email-orders.mdoc
@@ -70,8 +70,6 @@ faq:
       more of the blue valves, are applied on top of that historical order.
 ---
 
-# How AI Turns Messy Email Orders Into ERP-Ready Data
-
 Here is an email a distributor might receive at 7:43 AM on a Monday:
 
 > *"Hey Sandra, can you do the usual order plus 30 more of the blue 40mm fittings, and check if you have the larger size in that gate valve. Also we need 2 pallets of the 15mm copper pipe, same spec as February. Thanks, Martin"*

--- a/src/content/case-studies/meesenburg-order-automation.mdoc
+++ b/src/content/case-studies/meesenburg-order-automation.mdoc
@@ -45,8 +45,6 @@ faq:
       No. Unlike traditional OCR or template-based automation, OrderFlow does not use per-customer templates. It interprets the meaning of each order rather than matching characters against a fixed layout. This is what allows it to handle format changes and entirely new customer formats without breaking or requiring IT maintenance.
 ---
 
-# How Meesenburg Romania achieved 98% order accuracy with AI
-
 The order desk at Meesenburg Romania looked like most distribution operations. A small team, a shared inbox, and a daily flood of emails that each needed to be read, interpreted, matched to the right products, and keyed into the ERP. The work was steady, repetitive, and unforgiving. One misread quantity, one wrong SKU, and the downstream consequences (incorrect deliveries, credit notes, customer frustration) would ripple through the operation for days.
 
 What made Meesenburg's situation particularly difficult was not the volume of orders. It was the sheer diversity of how those orders arrived.


### PR DESCRIPTION
Removes duplicate H1 headings from article/case-study body content — these were already rendered by the page layout from frontmatter `title`, causing duplicate H1s on the page.