### PR TITLE
[seo] Fix CLS: load Google Fonts synchronously (NEU-585)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -168,9 +168,8 @@ const allJsonLd = [
   <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
   <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
 
-  <!-- Fonts -->
-  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Stack+Sans+Headline:wght@400;500;600&family=Caveat:wght@400&display=optional" />
-  <link href="https://fonts.googleapis.com/css2?family=Stack+Sans+Headline:wght@400;500;600&family=Caveat:wght@400&display=optional" rel="stylesheet" media="print" onload="this.media='all'" />
+  <!-- Fonts — synchronous load with font-display:optional prevents CLS from async @font-face injection (NEU-585) -->
+  <link href="https://fonts.googleapis.com/css2?family=Stack+Sans+Headline:wght@400;500;600&family=Caveat:wght@400&display=optional" rel="stylesheet" />
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />


### PR DESCRIPTION
## Summary

Fixes systemic CLS on all pages caused by the async `media=print` Google Fonts loading trick.

**Root cause:** The `media=print` + `onload` async font loading pattern deferred `@font-face` injection, causing a font-swap layout shift on cache-hit visits where the font briefly renders in fallback then swaps to Caveat/Stack Sans Headline.

**Fix:** Load the stylesheet synchronously. `font-display:optional` is unchanged — fonts that miss the budget are skipped rather than swapped, eliminating the shift while maintaining render performance.

## Before / After

| | Before |
|---|---|
| Pattern | `<link rel=preload as=style>` + `<link media=print onload=...>` |
| CLS | 0.53–0.62 (POOR) |

| | After |
|---|---|
| Pattern | `<link rel=stylesheet>` (synchronous) |
| CLS | Expected 0 (pending Lighthouse verification post-merge) |

**Branch:** `fix/neu-585-cls` **Issue:** NEU-585 / NEU-584