### PR TITLE
[seo] Defer GTM bootstrap to requestIdleCallback (NEU-585)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -78,12 +78,8 @@ const allJsonLd = [
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- Google Tag Manager -->
-  <script is:inline>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-PQPSNDHS');</script>
+  <!-- Google Tag Manager — deferred to idle to eliminate render-blocking impact (NEU-585) -->
+  <script is:inline>(function(){function loadGTM(){(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PQPSNDHS');}if('requestIdleCallback'in window){requestIdleCallback(loadGTM,{timeout:3000});}else{setTimeout(loadGTM,3000);}})();</script>
   <!-- End Google Tag Manager -->
 
   <meta charset="UTF-8" />


### PR DESCRIPTION
## Summary

Defers GTM-PQPSNDHS bootstrap from synchronous `<head>` execution to `requestIdleCallback` with a 3s timeout fallback, eliminating render-blocking main-thread work on page load.

**Root cause:** GTM bootstrap was inline and synchronous in `<head>`, blocking initial render and contributing to INP/FID metrics.

**Fix:** Wrap in `requestIdleCallback` (3s fallback via `setTimeout`). GA4 (G-Q9RW388339) and Google Ads (AW-16637671261) tags use separate deferred `gtag.js` loaders through GTM — they remain unaffected by this deferral.

## Verification

After deploy, confirm GA4 still receives events:
```
analytics ga4 realtime --id 412189963
```
Pageview should appear within 5s of a page load.

**Branch:** `fix/neu-585-gtm-defer` **Issue:** NEU-585 / NEU-584