### PR TITLE
fix: add 301 redirects from /insights/SLUG/ to new top-level paths (NEU-606)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -19,6 +19,12 @@ export default defineConfig({
   redirects: {
     '/demo': '/contact',
     '/articles': '/insights',
+    '/insights/esker-alternatives/': '/esker-alternatives/',
+    '/insights/conexiom-alternatives/': '/conexiom-alternatives/',
+    '/insights/meesenburg-order-automation/': '/meesenburg-order-automation/',
+    '/insights/order-processing-software-distributors/': '/order-processing-software-distributors/',
+    '/insights/sales-order-automation/': '/sales-order-automation/',
+    '/insights/what-is-sales-order/': '/insights/what-is-sales-order-automation/',
   },
   integrations: [
     react(),


### PR DESCRIPTION
## Summary

- PR #65 (NEU-610) moved 5 BOFU pages and the `what-is-sales-order` article from `/insights/SLUG/` to top-level routes without adding 301 redirects
- This caused 7 pages to 404, including `/insights/what-is-sales-order/` (the site's primary indexed organic article)
- Adds 6 permanent redirects in `astro.config.mjs` to preserve PageRank and fix all 404s

## Redirects added

| Old path | New path |
|---|---|
| `/insights/esker-alternatives/` | `/esker-alternatives/` |
| `/insights/conexiom-alternatives/` | `/conexiom-alternatives/` |
| `/insights/meesenburg-order-automation/` | `/meesenburg-order-automation/` |
| `/insights/order-processing-software-distributors/` | `/order-processing-software-distributors/` |
| `/insights/sales-order-automation/` | `/sales-order-automation/` |
| `/insights/what-is-sales-order/` | `/insights/what-is-sales-order-automation/` |

Note: `/insights/rpa-for-order-processing/` was excluded — it never existed in git history (per CEO instruction).

## Curl verification

Pending Vercel preview deployment from this PR. Will update with results once preview is available.

Expected per redirect:
```
HTTP/2 301
location: /esker-alternatives/
```

## Test plan

- [ ] Vercel preview deploys successfully
- [ ] All 6 old paths return 301 to correct new destination
- [ ] No regressions on existing `/demo` → `/contact` and `/articles` → `/insights` redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)