### PR TITLE
Move all BOFU articles to /insights/ routes + update redirects

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -19,12 +19,13 @@ export default defineConfig({
   redirects: {
     '/demo': '/contact',
     '/articles': '/insights',
-    '/insights/esker-alternatives/': '/esker-alternatives/',
-    '/insights/conexiom-alternatives/': '/conexiom-alternatives/',
     '/insights/meesenburg-order-automation/': '/meesenburg-order-automation/',
-    '/insights/order-processing-software-distributors/': '/order-processing-software-distributors/',
     '/insights/sales-order-automation/': '/sales-order-automation/',
     '/insights/what-is-sales-order/': '/insights/what-is-sales-order-automation/',
+    '/esker-alternatives/': '/insights/esker-alternatives/',
+    '/conexiom-alternatives/': '/insights/conexiom-alternatives/',
+    '/order-processing-software-distributors/': '/insights/order-processing-software-distributors/',
+    '/purchase-order-automation-software/': '/insights/purchase-order-automation-software/',
   },
   integrations: [
     react(),

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -4,19 +4,12 @@ import '../styles/content.css';
 import { getCollection, render } from 'astro:content';
 
 export async function getStaticPaths() {
-  const [articles, pages, caseStudies] = await Promise.all([
-    getCollection('articles'),
+  const [pages, caseStudies] = await Promise.all([
     getCollection('pages'),
     getCollection('caseStudies'),
   ]);
 
-  const bofuArticles = articles.filter((a) => a.data.funnel === 'BOFU');
-
   return [
-    ...bofuArticles.map((entry) => ({
-      params: { slug: entry.id },
-      props: { entry, contentType: 'article' as const, allArticles: articles },
-    })),
     ...pages.map((entry) => ({
       params: { slug: entry.id },
       props: { entry, contentType: 'page' as const },

--- a/src/pages/insights.astro
+++ b/src/pages/insights.astro
@@ -35,7 +35,7 @@ type InsightItem = {
 const allItems: InsightItem[] = [
   ...articles.map((a) => ({
     id: a.id,
-    url: a.data.funnel === 'BOFU' ? `/${a.id}` : `/insights/${a.id}`,
+    url: `/insights/${a.id}`,
     title: a.data.title,
     date: a.data.date || '',
     dateFormatted: formatDate(a.data.date || ''),

--- a/src/pages/insights/[slug].astro
+++ b/src/pages/insights/[slug].astro
@@ -5,9 +5,8 @@ import { getCollection, render } from 'astro:content';
 
 export async function getStaticPaths() {
   const articles = await getCollection('articles');
-  const nonBofuArticles = articles.filter((a) => a.data.funnel !== 'BOFU');
 
-  return nonBofuArticles.map((entry) => ({
+  return articles.map((entry) => ({
     params: { slug: entry.id },
     props: { entry, contentType: 'article' as const, allArticles: articles },
   }));


### PR DESCRIPTION
## Summary

- `insights/[slug].astro`: removed non-BOFU filter — ALL articles now served at `/insights/[slug]`
- `[slug].astro`: removed BOFU article routes; now handles only pages + caseStudies
- `insights.astro`: article card URLs unified to `/insights/SLUG` (removed BOFU conditional)
- `astro.config.mjs`: removed 3 stale `/insights/X/ → /X/` redirects; added 4 new `/X/ → /insights/X/` redirects (including `/purchase-order-automation-software/`)

## Build verification

All 4 BOFU articles confirmed at `/insights/` routes in sitemap:
- `/insights/conexiom-alternatives/` ✅
- `/insights/esker-alternatives/` ✅
- `/insights/purchase-order-automation-software/` ✅
- `/insights/order-processing-software-distributors/` ✅

Closes NEU-620. Part of NEU-598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)