### PR TITLE
Remove test-pipeline page

### DIFF
--- a/src/content/pages/test-pipeline.mdoc
+++ b/src/content/pages/test-pipeline.mdoc
@@ -1,7 +1,0 @@
----
-title: Test Pipeline
-seoTitle: Test Pipeline | Orderflow
-seoDescription: Internal test page to verify the content-to-live pipeline.
----
-
-This is an internal test page used to verify that the content-to-live pipeline is working correctly. It confirms that new entries in the pages collection are rendered and appear in the sitemap.


### PR DESCRIPTION
## Summary
- Deletes `src/content/pages/test-pipeline.mdoc` (the test landing page added in PR #67)
- Page was a temporary pipeline verification artifact; board requested deletion

## Test plan
- [ ] `/test-pipeline/` returns 404 after merge
- [ ] Sitemap no longer includes `orderflow.biz/test-pipeline/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)