### PR TITLE
Fix mobile LCP: NO_LCP on /about/ and /insights/ + preload hero images (NEU-628)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,6 +11,7 @@ interface Props {
   canonical?: string;
   ogImage?: string;
   ogType?: string;
+  lcpImage?: string;
   article?: {
     publishedTime: string;
     modifiedTime?: string;
@@ -153,6 +154,9 @@ const allJsonLd = [
     :root{--header-height:88px}
     main{padding-top:var(--header-height)}
   </style>
+
+  <!-- LCP image preload — injects a high-priority preload hint so the browser fetches the above-fold hero image as early as possible (before the HTML parser reaches the <img> element) -->
+  {props.lcpImage && <link rel="preload" as="image" href={props.lcpImage} fetchpriority="high" />}
 
   <!-- Preconnect to critical origins -->
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -176,6 +176,7 @@ function formatDate(dateStr: string): string {
   description={pageDescription}
   canonical={pageUrl}
   ogImage={heroImage}
+  lcpImage={heroImage}
   ogType={ogType}
   noindex={noindex}
   article={articleMeta}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -62,8 +62,8 @@ const aboutPageSchema = {
             </svg>
           </div>
           <p class="about-hero__eyebrow" data-reveal="up" style="--delay:0.05s">About Orderflow</p>
-          <h1 id="about-hero-heading" class="about-hero__title" data-reveal="up" style="--delay:0.1s">We believe no order should wait on a human to retype it.</h1>
-          <p class="about-hero__subtitle" data-reveal="up" style="--delay:0.2s">Orderflow exists because distribution businesses deserve technology that adapts to their customers, not the other way around.</p>
+          <h1 id="about-hero-heading" class="about-hero__title">We believe no order should wait on a human to retype it.</h1>
+          <p class="about-hero__subtitle">Orderflow exists because distribution businesses deserve technology that adapts to their customers, not the other way around.</p>
           <div class="about-hero__badges" data-reveal="up" style="--delay:0.3s">
             <span class="about-hero__badge">
               <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#00A63E"/><path d="M6.25 10L8.75 12.5L13.75 7.5" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -108,9 +108,9 @@ const faqSchema = {
     <section class="section section--hero" aria-labelledby="hero-heading">
       <div class="section__card section__card--muted">
         <div class="hero__text">
-          <h1 id="hero-heading" class="hero__title" data-reveal="up">Stop manually processing orders</h1>
-          <p class="hero__subtitle" data-reveal="up" style="--delay:0.1s">Every order, any format, automated.</p>
-          <div class="hero__cta" data-reveal="up" style="--delay:0.2s">
+          <h1 id="hero-heading" class="hero__title">Stop manually processing orders</h1>
+          <p class="hero__subtitle">Every order, any format, automated.</p>
+          <div class="hero__cta" data-reveal="up" style="--delay:0.1s">
             <a href="/contact" class="btn btn--dark">See it in action</a>
           </div>
         </div>

--- a/src/pages/insights.astro
+++ b/src/pages/insights.astro
@@ -87,6 +87,7 @@ const allTags = [...new Set(allItems.map((item) => item.filterTag))];
 <BaseLayout
   title="Insights | Order Processing Automation | Orderflow"
   description="Explore articles and insights on AI-powered order processing, distribution automation, and ERP integration for modern businesses."
+  lcpImage={sortedItems[0]?.image}
   jsonLd={breadcrumbSchema}
 >
   <main>
@@ -94,8 +95,8 @@ const allTags = [...new Set(allItems.map((item) => item.filterTag))];
     <section class="section section--insights-hero">
       <div class="section__card section__card--muted insights-hero">
         <div class="insights-hero__text">
-          <h1 class="insights-hero__title" data-reveal="up">Insights</h1>
-          <p class="insights-hero__subtitle" data-reveal="up" style="--delay:0.1s">Explore our latest insights on order automation, industry updates, and scaling distribution operations.</p>
+          <h1 class="insights-hero__title">Insights</h1>
+          <p class="insights-hero__subtitle">Explore our latest insights on order automation, industry updates, and scaling distribution operations.</p>
         </div>
         <div class="insights-hero__tags" data-reveal="up" style="--delay:0.2s">
           <button class="tag tag--active" data-filter="all">All</button>
@@ -117,7 +118,7 @@ const allTags = [...new Set(allItems.map((item) => item.filterTag))];
         <!-- Article grid -->
         <div class="article-grid" id="article-grid" data-reveal-stagger>
           {sortedItems.map((item, index) => (
-            <a href={item.url} class="article-card" data-reveal="up" data-tag={item.filterTag}>
+            <a href={item.url} class="article-card" data-tag={item.filterTag} {...(index > 0 ? {'data-reveal': 'up'} : {})}>
               <div class="article-card__image-wrap">
                 {item.image && <img src={item.image} alt={item.title} class="article-card__image" width="816" height="640" loading={index === 0 ? 'eager' : 'lazy'} fetchpriority={index === 0 ? 'high' : undefined}>}
                 {(item.category || item.contentTypeLabel) && (

--- a/src/pages/insights/[slug].astro
+++ b/src/pages/insights/[slug].astro
@@ -173,6 +173,7 @@ function formatDate(dateStr: string): string {
   title={pageTitle}
   description={pageDescription}
   ogImage={heroImage}
+  lcpImage={heroImage}
   ogType={ogType}
   noindex={noindex}
   article={articleMeta}


### PR DESCRIPTION
## Summary

- **NO_LCP on /about/ and /insights/ (P0):** `data-reveal="up"` was setting `opacity:0` on the `<h1>` elements. Lighthouse's LCP trace window closed before the IntersectionObserver fired on a simulated slow mobile CPU, so no LCP candidate was ever registered. Fixed by removing `data-reveal` from `<h1>` (and subtitle) in both hero sections and on the homepage hero, so they render immediately.
- **LCP > 2.5s on article/BOFU pages (P1):** Added an optional `lcpImage` prop to `BaseLayout` that injects `<link rel="preload" as="image" fetchpriority="high">` in `<head>` — giving the browser the earliest possible signal to start fetching the hero image. Both `[slug].astro` templates (insights + BOFU/pages) now pass `heroImage` as `lcpImage`.
- **First article card on /insights/:** Also removes `data-reveal` from the first article card so Lighthouse can use its `loading="eager"` image as an LCP candidate.

## Test plan

- [ ] Load /about/ — h1 renders immediately (no fade-in), Lighthouse reports valid LCP instead of NO_LCP
- [ ] Load /insights/ — h1 and first article card render immediately
- [ ] Load homepage — h1 renders without delay; CTA button still fades in (kept data-reveal)
- [ ] Load any insight article — check DevTools Network tab shows preload request for hero image in first waterfall entry
- [ ] Run Lighthouse mobile on /about/, /insights/, one article, homepage — verify LCP improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)