### PR TITLE
[cls] Fix CLS 0.159 on insight pages via critical CSS additions (NEU-629)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -152,6 +152,11 @@ const allJsonLd = [
     .site-header{position:absolute;top:0;left:0;right:0;z-index:50;background-color:var(--color-white);overflow:hidden}
     :root{--header-height:88px}
     main{padding-top:var(--header-height)}
+    .site-header__inner{display:flex;align-items:center;gap:var(--space-64);padding:var(--space-24) var(--space-32) var(--space-16);max-width:var(--max-width);margin:0 auto}
+    .nav-links{display:flex;flex:1;gap:var(--space-8);align-items:center;list-style:none}
+    .mobile-menu-toggle{display:none}
+    .insight-hero{position:relative;min-height:420px;margin:var(--space-16);overflow:hidden}
+    .insight-hero__overlay{position:absolute;inset:0}
   </style>
 
   <!-- Preconnect to critical origins -->


### PR DESCRIPTION
Fixes CLS 0.1573 on all insight pages by adding 5 critical CSS rules to the inline style block in BaseLayout.astro. NEU-629.